### PR TITLE
Fix guides tag rendering for Discourse payloads

### DIFF
--- a/src/pages/Guides.jsx
+++ b/src/pages/Guides.jsx
@@ -14,6 +14,12 @@ const formatDate = (value) => {
   }).format(date);
 };
 
+const normalizeTagLabel = (tag) => {
+  if (!tag) return '';
+  if (typeof tag === 'string') return tag;
+  return tag.name || tag.slug || '';
+};
+
 export default function Guides() {
   const sentinelRef = useRef(null);
   const [topics, setTopics] = useState([]);
@@ -169,14 +175,18 @@ function GuideCard({ topic }) {
         </h3>
         {topic.tags?.length ? (
           <div className="flex flex-wrap gap-2">
-            {topic.tags.slice(0, 4).map((tag) => (
-              <span
-                key={tag}
-                className="rounded-full border border-white/15 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-200 transition-colors duration-300 group-hover:border-sky-200/40 group-hover:text-white"
-              >
-                {tag}
-              </span>
-            ))}
+            {topic.tags.slice(0, 4).map((tag, index) => {
+              const label = normalizeTagLabel(tag);
+              if (!label) return null;
+              return (
+                <span
+                  key={`${label}-${index}`}
+                  className="rounded-full border border-white/15 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-200 transition-colors duration-300 group-hover:border-sky-200/40 group-hover:text-white"
+                >
+                  {label}
+                </span>
+              );
+            })}
           </div>
         ) : null}
 


### PR DESCRIPTION
### Motivation
- The Guides page could receive tag items as objects from the Discourse API which caused React to try rendering objects as children and produce a runtime error.

### Description
- Add `normalizeTagLabel` to `src/pages/Guides.jsx` to safely extract a string label from a tag that may be a string or an object (`name` or `slug`).
- Update the tag rendering loop to call `normalizeTagLabel`, skip empty labels, and use a stable string-based `key` (`${label}-${index}`) when rendering tag pills.
- Keep all other guides loading and pagination logic unchanged.

### Testing
- Started the dev server (`vite`) and confirmed it reported ready with the local URL, which succeeded. 
- Ran an automated Playwright script to open `/guides` and capture a screenshot, which completed and produced `artifacts/guides.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982cc5589d483259aa477fd6d7a5764)